### PR TITLE
Timetable css

### DIFF
--- a/templates/timetable.html
+++ b/templates/timetable.html
@@ -1,111 +1,109 @@
 <!DOCTYPE html>
 <html>
-<head>
-      <meta charset="utf-8">
+  <head>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../static/assets/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="../static/assets/css/user.css">
     <title>JIIT Time Table Extractor</title>
-    
-<style>
-.tableStyle{
-  width: 100%;
-  border-collapse: collapse;
-  text-align: center;
-}
+    <style>
 
-th{
+    .time-table {
+      border-bottom: 1px solid #e7e7e7;
+    }
 
-  background-color: lightgrey;
-  padding:5px;
+    .table {
+      margin-bottom: 0;
+    }
 
-}
+    th {
+      background-color: #e7e7e7;
+      border-right: 1px solid #cecece!important;
+    }
 
-table,tr,th,td{
-  border: 1px solid black;
-}
+    td {
+      border-right: 1px solid #cecece!important;
+    }
 
-td{
-  padding:5px;
-}
+    </style>
+  </head>
+  <body>
+    <div class="time-table table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Days/Time</th>
+            <th>9 - 9:50 AM</th>
+            <th>9:55 - 10:45 AM</th>
+            <th>10:50 - 11:40 AM </th>
+            <th>11:45 - 12:35 PM</th>
+            <th>12:40 - 1:30 PM</th>
+            <th>1:35 - 2:25PM</th>
+            <th>2:30 - 3:20 PM</th>
+            <th>3:25 - 4:15 PM</th>
+            <th>04:20 - 5:10 PM</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="table__day">Mon</td>
 
-</style>
-</head>
-<body>
-<table class ="tableStyle" style="width:100%;">
+            {%for i in range(0,9)%}
 
-  <tr>
-    <th >Days/Time</th>
-    <th >9-9:50 AM</th>
-    <th >9:55-10:45 AM </th>
-    <th >10:50-11:40 AM  </th>
-    <th >11:45-12:35 PM</th>
-    <th >12:40- 1:30 PM</th>
-    <th >1:35-2:25PM</th>
-    <th >2:30-3:20 PM</th>
-    <th >3:25-4:15 PM</th>
-    <th >04:20 -5:10 PM</th>
-  </tr>
-
-
-  <tr>
-    <td>Mon</td>
-
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Mon'][i]}}</td>
-{%endfor%}
-  </tr>
+            <td>{{tt_dict['Mon'][i]}}</td>
+            {%endfor%}
+          </tr>
 
 
-  <tr>
-    <td>Tue</td>
+          <tr>
+            <td class="table__day">Tue</td>
 
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Tue'][i]}}</td>
-{%endfor%}
-  </tr>
+            {%for i in range(0,9)%}
 
-
-  <tr>
-    <td>Wed</td>
-
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Wed'][i]}}</td>
-{%endfor%}
-  </tr>
+            <td>{{tt_dict['Tue'][i]}}</td>
+            {%endfor%}
+          </tr>
 
 
-  <tr>
-    <td>Thu</td>
+          <tr>
+            <td class="table__day">Wed</td>
 
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Thu'][i]}}</td>
-{%endfor%}
-  </tr>
+            {%for i in range(0,9)%}
 
-
-  <tr>
-    <td>Fri</td>
-
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Fri'][i]}}</td>
-{%endfor%}
-  </tr>
+            <td>{{tt_dict['Wed'][i]}}</td>
+            {%endfor%}
+          </tr>
 
 
-  <tr>
-    <td>Sat</td>
+          <tr>
+            <td class="table__day">Thu</td>
 
-    {%for i in range(0,9)%}
- 
-    <td>{{tt_dict['Sat'][i]}}</td>
-{%endfor%}
-  </tr>
+            {%for i in range(0,9)%}
 
-</table>
+            <td>{{tt_dict['Thu'][i]}}</td>
+            {%endfor%}
+          </tr>
 
-</body>
+
+          <tr>
+            <td class="table__day">Fri</td>
+
+            {%for i in range(0,9)%}
+
+            <td>{{tt_dict['Fri'][i]}}</td>
+            {%endfor%}
+          </tr>
+
+
+          <tr>
+            <td class="table__day">Sat</td>
+            {%for i in range(0,9)%}
+
+            <td>{{tt_dict['Sat'][i]}}</td>
+            {%endfor%}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Issue: #6

- Improve table markup 
- Reindent
- Add Bootstrap classes 
<img width="1280" alt="screen shot 2018-10-11 at 21 27 31" src="https://user-images.githubusercontent.com/15093848/46832572-4c187c00-cd9e-11e8-8d37-fc98f99973c3.png">


I had an idea to make it more responsive but it is hard since we have a loop for the classes like 
``` 
 {%for i in range(0,9)%}
<td>{{tt_dict['Mon'][i]}}</td>
 {%endfor%}
``` 
But nothing for the time of the day (Just hard-coded in the head).  I wanted to hide/show markup on smaller screens but I don't know how to write a loop that will only give the times that have classes (or at least let me know which ones are empty). It would be easier if I could match the classes with the time of day somehow :) 

Anyway I don't know Python.. 
But I hope this helps a little :) 